### PR TITLE
Enable Eslint extension for recommended rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,11 @@
     "es6": true,
     "node": true
   },
-  "extends": ["airbnb-base", "prettier/@typescript-eslint"],
+  "extends": [
+    "airbnb-base",
+    "prettier/@typescript-eslint",
+    "eslint:recommended"
+  ],
   "globals": {
     "Atomics": "readonly",
     "SharedArrayBuffer": "readonly"


### PR DESCRIPTION
By default Eslint doesn't use rules when you create its configuration file. But they've an extension that use rules to report code pieces that eventually produce problems.

You can check those rules here: https://eslint.org/docs/rules/