### PR TITLE
Changed to the correct environment variable name on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ yarn start
 
 **Application Options**
 
-- `APP_PORT`: Set the port of the application
+- `PORT`: Set the port of the application
 
 ## Scripts
 


### PR DESCRIPTION
For those who wasn't watching @lucasmontano stream, he tried to run the app using APP_PORT, but it didn't work. Changing that to PORT only makes the app works perfectly. That's why I'm doing this modification on readme.