### PR TITLE
improve lint-staged with jest and prettier

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,9 @@
  
 {
-    "src/**/*.{ts,js}": ["eslint --fix"]
+    "src/**/*.{ts,js}": [
+        "eslint --fix",
+        "jest",
+        "prettier --check --write 'src/**/*.{ts,js}'",
+        "git add"
+    ]
 }


### PR DESCRIPTION
Improve `lint-staged` with:
- `jest`
- `prettier`

### Why?

- with jest you guarantee that you will not commit with broken tests
- with the prettier ensures that the code will be formatted at commit time

### lint-staged now

```
{
    "src/**/*.{ts,js}": [
        "eslint --fix",
        "jest",
        "prettier --check --write 'src/**/*.{ts,js}'",
        "git add"
    ]
}
```